### PR TITLE
Fix: Correct decimal truncation and prevent KeyError for sensors

### DIFF
--- a/custom_components/siemens_ozw672/sensor.py
+++ b/custom_components/siemens_ozw672/sensor.py
@@ -362,11 +362,18 @@ class SiemensOzw672NumberSensor(SiemensOzw672Entity,SensorEntity):
         _LOGGER.debug(f'SiemensOzw672GenericNumberSensor: Data: {self.coordinator.data}')
         item=self.config_entry["Id"]
         data=self.coordinator.data[item]["Data"]["Value"].strip()
-        if data.isnumeric() and self.config_entry["DPDescr"]["DecimalDigits"] != "0":
-            return float(data)
+        # Fix to show decimal numbers
+        decimal_digits = self.config_entry.get("DPDescr", {}).get("DecimalDigits", "1")
+        if (data.isnumeric() or is_float(data)) and decimal_digits != "0":
+            try:
+                return float(data)
+            except ValueError:
+                return data
         else:
-            return int(float(data))
-        return data
+            try:
+                return int(float(data))
+            except:
+                return data
 
     @property
     def native_value(self):
@@ -374,11 +381,18 @@ class SiemensOzw672NumberSensor(SiemensOzw672Entity,SensorEntity):
         _LOGGER.debug(f'SiemensOzw672GenericNumberSensor: Native Data: {self.coordinator.data}')
         item=self.config_entry["Id"]
         data=self.coordinator.data[item]["Data"]["Value"].strip()
-        if data.isnumeric() and self.config_entry["DPDescr"]["DecimalDigits"] != "0":
-            return float(data)
+        # Fix to show decimal numbers
+        decimal_digits = self.config_entry.get("DPDescr", {}).get("DecimalDigits", "1")
+        if (data.isnumeric() or is_float(data)) and decimal_digits != "0":
+            try:
+                return float(data)
+            except ValueError:
+                return data
         else:
-            return int(float(data))
-        return data
+            try:
+                return int(float(data))
+            except:
+                return data
 
     @property
     def icon(self):


### PR DESCRIPTION
Hi All, 
Here are the changes to the code to fix the decimal values for Water Pressure sensor and heating curve. It works for me.

Palo

Changes made:

Fixed Decimal Truncation: Changed isnumeric() checks and int(float(data)) conversions to allow float values. The previous logic was truncating values like 1.4 to 1 and 0.45 to 0 because isnumeric() returns False for strings containing a decimal point.

Added KeyError Protection: Improved the way DecimalDigits is accessed using the .get() method. Some datapoints (like water pressure) do not provide the DecimalDigits key, which was causing the integration to crash with a KeyError during entity setup.

Improved Robustness: Added try-except blocks around float conversions to ensure the sensor remains available even if the API returns unexpected data formats.